### PR TITLE
Skip subdomain override if provided

### DIFF
--- a/app/Commands/ShareCurrentWorkingDirectoryCommand.php
+++ b/app/Commands/ShareCurrentWorkingDirectoryCommand.php
@@ -10,9 +10,10 @@ class ShareCurrentWorkingDirectoryCommand extends ShareCommand
     {
         $this->input->setArgument('host', basename(getcwd()).'.'.$this->detectTld());
 
-        $subdomain = str_replace('.', '_', basename(getcwd()));
-
-        $this->input->setOption('subdomain', $subdomain);
+        if (! $this->hasOption('subdomain')) {
+            $subdomain = str_replace('.', '_', basename(getcwd()));
+            $this->input->setOption('subdomain', $subdomain);
+        }
 
         parent::handle();
     }


### PR DESCRIPTION
Hello Marce. 

This PR FIxes #12 . it allows default command to pass subdomain and only override if missing

```
expose --subdomain=bar
```