### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+tests
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM php:7.4-cli
+
+RUN apt-get update
+RUN apt-get install -y git libzip-dev zip
+
+RUN docker-php-ext-install zip
+
+# install composer
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
+    && php composer-setup.php --install-dir=/usr/local/bin --filename=composer \
+    && rm composer-setup.php
+
+COPY . /app
+
+# install the dependencies
+RUN cd /app && composer install -o --prefer-dist && chmod a+x /app/expose
+
+ENTRYPOINT ["/app/expose"]


### PR DESCRIPTION
This is the Dockerfile for end-users only rather than development.

Currently the builds are failing because the dependencies cannot be installed but I managed to make it work on `1.0.1`. https://scrutinizer-ci.com/g/beyondcode/expose/inspections/a1b9f720-7668-40a3-bebb-3e7401162934

## Build

```
docker build -t expose .
```

## Run

```
docker run -it \
    -v <YOUR EXPOSE CONFIG FILE PATH>:/root/.expose/config.php \
    expose expose

docker run -it expose serve my-domain.com
```

@mpociot You also better add it to docker hub. The automated builds on docker hub should work without requiring any trick as long as you add proper versioning. You can configure it just like in the screenshot.

![Screen Shot 2020-06-19 at 19 37 25](https://user-images.githubusercontent.com/1162691/85157598-5b82e480-b264-11ea-85d2-83d4d0030502.png)
