### PR TITLE
Update .gitattributes to export-ignore tests, docs, and other build files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,14 @@
 * text=auto
-/.github export-ignore
-.styleci.yml export-ignore
+
+/.github         export-ignore
+/tests           export-ignore
+/docs            export-ignore
+.gitattributes   export-ignore
+.gitignore       export-ignore
+.styleci.yml     export-ignore
 .scrutinizer.yml export-ignore
-BACKERS.md export-ignore
-CONTRIBUTING.md export-ignore
-CHANGELOG.md export-ignore
+BACKERS.md       export-ignore
+CONTRIBUTING.md  export-ignore
+CHANGELOG.md     export-ignore
+nodemod.json     export-ignore
+phpunit.xml.dist export-ignore


### PR DESCRIPTION
Thanks for starting this cool project!

I noticed that the `.gitattributes` file `export-ignore` rules were a little out of date, hence this PR. Excluding the `builds/expose` file (which I believe should not be bundled, but that's for another discussion), this PR reduces the zip file download size from 132kb to 106kb with standard GitHub zip downloads. 

Thank you.