### PR TITLE
fix remaining time calculation

### DIFF
--- a/app/Client/Client.php
+++ b/app/Client/Client.php
@@ -108,10 +108,11 @@ class Client
                     $this->loop->addPeriodicTimer(1, function () use ($data, $timeoutSection) {
                         $this->timeConnected++;
 
-                        $carbon = Carbon::createFromFormat('s', str_pad($data->length * 60 - $this->timeConnected, 2, 0, STR_PAD_LEFT));
+                        $secondsRemaining = $data->length * 60 - $this->timeConnected;
+                        $remaining = Carbon::now()->diff(Carbon::now()->addSeconds($secondsRemaining));
 
                         $timeoutSection->clear();
-                        $timeoutSection->writeln('Remaining time: '.$carbon->format('H:i:s'));
+                        $timeoutSection->writeln('Remaining time: '.$remaining->format('%H:%I:%S'));
                     });
                 });
 


### PR DESCRIPTION
Hi,

After some testing I noticed a little bug in the calculation of remaining time when using `maximum_connection_length` option on the server.

`DateTime::createFromFormat('s', $seconds)` [can only take seconds up to 99 (max 2 digits) seconds](https://web.tinkerwell.app/#/snippets/e64588b5-1ed8-4fc4-944a-f36652d8d20b). If remaining time is more, the following error appears:

![image](https://user-images.githubusercontent.com/4414498/85639573-676a0e80-b689-11ea-9e4f-c50a0cb7bc09.png)

(I didn't add any tests as I'm new to reactphp and simply don't know how to set this up, hope this fix help anyway 😅)