### PR TITLE
Don't use underscore in subdomain

### DIFF
--- a/app/Commands/ShareCurrentWorkingDirectoryCommand.php
+++ b/app/Commands/ShareCurrentWorkingDirectoryCommand.php
@@ -13,7 +13,7 @@ class ShareCurrentWorkingDirectoryCommand extends ShareCommand
         $this->input->setArgument('host', $host);
 
         if (! $this->option('subdomain')) {
-            $subdomain = str_replace('.', '_', basename(getcwd()));
+            $subdomain = str_replace('.', '-', basename(getcwd()));
             $this->input->setOption('subdomain', $subdomain);
         }
 


### PR DESCRIPTION
Even though it's perfectly valid, some providers (Paddle in our case) don't validate URLs with an underscore in them as valid, an easy fix is just using a dash instead.