### PR TITLE
Add simple pagination to users page 

### DIFF
--- a/app/Contracts/UserRepository.php
+++ b/app/Contracts/UserRepository.php
@@ -10,6 +10,8 @@ interface UserRepository
 
     public function getUserById($id): PromiseInterface;
 
+    public function paginateUsers(int $perPage, int $currentPage): PromiseInterface;
+
     public function getUserByToken(string $authToken): PromiseInterface;
 
     public function storeUser(array $data): PromiseInterface;

--- a/app/Server/Http/Controllers/Admin/GetUsersController.php
+++ b/app/Server/Http/Controllers/Admin/GetUsersController.php
@@ -21,10 +21,10 @@ class GetUsersController extends AdminController
     public function handle(Request $request, ConnectionInterface $httpConnection)
     {
         $this->userRepository
-            ->getUsers()
-            ->then(function ($users) use ($httpConnection) {
+            ->paginateUsers(20, (int) $request->get('page', 1))
+            ->then(function ($paginated) use ($httpConnection) {
                 $httpConnection->send(
-                    respond_json(['users' => $users])
+                    respond_json(['paginated' => $paginated])
                 );
 
                 $httpConnection->close();

--- a/app/Server/Http/Controllers/Admin/ListUsersController.php
+++ b/app/Server/Http/Controllers/Admin/ListUsersController.php
@@ -21,10 +21,10 @@ class ListUsersController extends AdminController
     public function handle(Request $request, ConnectionInterface $httpConnection)
     {
         $this->userRepository
-            ->getUsers()
-            ->then(function ($users) use ($httpConnection) {
+            ->paginateUsers(20, (int) $request->get('page', 1))
+            ->then(function ($paginated) use ($httpConnection) {
                 $httpConnection->send(
-                    respond_html($this->getView($httpConnection, 'server.users.index', ['users' => $users]))
+                    respond_html($this->getView($httpConnection, 'server.users.index', ['paginated' => $paginated]))
                 );
 
                 $httpConnection->close();

--- a/resources/views/server/users/index.twig
+++ b/resources/views/server/users/index.twig
@@ -75,6 +75,27 @@
                 </tr>
                 </tbody>
             </table>
+
+            <div class="flex items-center justify-end text-gray-900 p-4" v-if="paginated.current_page > 0">
+                <button
+                    :disabled="paginated.previous_page == null"
+                    v-on:click="getUsers(paginated.previous_page)"
+                    type="button"
+                    :class="(paginated.previous_page == null ? 'opacity-50 cursor-not-allowed' : '') + ' mr-3 py-2 px-4 border border-gray-300 rounded-md text-sm leading-5 font-medium text-gray-700 hover:text-gray-500 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-50 active:text-gray-800 transition duration-150 ease-in-out'"
+                >
+                    Previous
+                </button>
+
+                <button
+                    :disabled="paginated.next_page == null"
+                    v-on:click="getUsers(paginated.next_page)"
+                    type="button"
+                    :class="(paginated.next_page == null ? 'opacity-50 cursor-not-allowed' : '') + ' py-2 px-4 border border-gray-300 rounded-md text-sm leading-5 font-medium text-gray-700 hover:text-gray-500 focus:outline-none focus:border-blue-300 focus:shadow-outline-blue active:bg-gray-50 active:text-gray-800 transition duration-150 ease-in-out'"
+                >
+                    Next
+                </button>
+            </div>
+
             <div class="flex items-center justify-center text-gray-900 p-4" v-else>
                 <span class="text-xl">The expose server does not have any users yet.</span>
             </div>
@@ -94,10 +115,25 @@
                         name: '',
                         errors: {},
                     },
-                    users: {{ users|json_encode|raw }}
+                    paginated: {{ paginated|json_encode|raw }}
+                },
+
+                computed: {
+                    users : function() {
+                        return this.paginated.users;
+                    }
                 },
 
                 methods: {
+                    getUsers(page) {
+                        fetch('/api/users?page=' + page)
+                            .then((response) => {
+                                return response.json();
+                            }).then((data) => {
+                                this.paginated = data.paginated;
+                            });
+                    },
+
                     deleteUser(user) {
                         fetch('/api/users/' + user.id, {
                             method: 'DELETE',


### PR DESCRIPTION
This PR implements a very basic pagination on the users page regarding issue #51 .

![image](https://user-images.githubusercontent.com/8272048/85847380-8fe82a80-b7a7-11ea-99f2-d85daba0fb89.png)

If it's got merged the upcoming PR I would try to make is to add search input so it's easy to filter users by name or token.

