### PR TITLE
Add SSL option for clients to allow non-standard port options

### DIFF
--- a/app/Client/Client.php
+++ b/app/Client/Client.php
@@ -72,7 +72,7 @@ class Client
         $deferred = new Deferred();
         $promise = $deferred->promise();
 
-        $wsProtocol = $this->configuration->port() === 443 ? 'wss' : 'ws';
+        $wsProtocol = $this->configuration->ssl() ? 'wss' : 'ws';
 
         connect($wsProtocol."://{$this->configuration->host()}:{$this->configuration->port()}/expose/control?authToken={$authToken}", [], [
             'X-Expose-Control' => 'enabled',
@@ -117,12 +117,8 @@ class Client
                 });
 
                 $connection->on('authenticated', function ($data) use ($deferred, $sharedUrl) {
-                    $httpProtocol = $this->configuration->port() === 443 ? 'https' : 'http';
-                    $host = $this->configuration->host();
-
-                    if ($httpProtocol !== 'https') {
-                        $host .= ":{$this->configuration->port()}";
-                    }
+                    $httpProtocol = $this->configuration->ssl() ? 'https' : 'http';
+                    $host = $this->getHost();
 
                     $this->logger->info($data->message);
                     $this->logger->info("Local-URL:\t\t{$sharedUrl}");
@@ -171,5 +167,18 @@ class Client
         } else {
             exit(1);
         }
+    }
+
+    private function getHost()
+    {
+        $host = $this->configuration->host();
+        if ($this->configuration->port() === 80 && ! $this->configuration->ssl()) {
+            return $host;
+        }
+        if ($this->configuration->port() === 443 && $this->configuration->ssl()) {
+            return $host;
+        }
+
+        return "{$host}:{$this->configuration->port()}";
     }
 }

--- a/app/Client/Configuration.php
+++ b/app/Client/Configuration.php
@@ -13,13 +13,18 @@ class Configuration
     /** @var string|null */
     protected $auth;
 
-    public function __construct(string $host, int $port, ?string $auth = null)
+    /** @var bool|null */
+    protected $ssl;
+
+    public function __construct(string $host, int $port, ?string $auth = null, $ssl = null)
     {
         $this->host = $host;
 
         $this->port = $port;
 
         $this->auth = $auth;
+
+        $this->ssl = $ssl;
     }
 
     public function host(): string
@@ -35,5 +40,14 @@ class Configuration
     public function port(): int
     {
         return intval($this->port);
+    }
+
+    public function ssl(): bool
+    {
+        if ($this->ssl === null) {
+            return $this->port() === 443;
+        }
+
+        return boolval($this->ssl);
     }
 }

--- a/app/Client/Factory.php
+++ b/app/Client/Factory.php
@@ -27,6 +27,9 @@ class Factory
     /** @var string */
     protected $auth = '';
 
+    /** @var bool|null */
+    protected $ssl = null;
+
     /** @var \React\EventLoop\LoopInterface */
     protected $loop;
 
@@ -63,6 +66,13 @@ class Factory
         return $this;
     }
 
+    public function setSsl(?bool $ssl)
+    {
+        $this->ssl = $ssl;
+
+        return $this;
+    }
+
     public function setLoop(LoopInterface $loop)
     {
         $this->loop = $loop;
@@ -73,7 +83,7 @@ class Factory
     protected function bindConfiguration()
     {
         app()->singleton(Configuration::class, function ($app) {
-            return new Configuration($this->host, $this->port, $this->auth);
+            return new Configuration($this->host, $this->port, $this->auth, $this->ssl);
         });
     }
 

--- a/app/Client/ProxyManager.php
+++ b/app/Client/ProxyManager.php
@@ -23,7 +23,7 @@ class ProxyManager
 
     public function createProxy(string $clientId, $connectionData)
     {
-        $protocol = $this->configuration->port() === 443 ? 'wss' : 'ws';
+        $protocol = $this->configuration->ssl() ? 'wss' : 'ws';
 
         connect($protocol."://{$this->configuration->host()}:{$this->configuration->port()}/expose/control", [], [
             'X-Expose-Control' => 'enabled',

--- a/app/Commands/ShareCommand.php
+++ b/app/Commands/ShareCommand.php
@@ -31,6 +31,7 @@ class ShareCommand extends Command
             ->setLoop(app(LoopInterface::class))
             ->setHost(config('expose.host', 'localhost'))
             ->setPort(config('expose.port', 8080))
+            ->setSsl(config('expose.ssl', null))
             ->setAuth($this->option('auth'))
             ->createClient()
             ->share($this->argument('host'), explode(',', $this->option('subdomain')))

--- a/config/expose.php
+++ b/config/expose.php
@@ -31,6 +31,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | SSL
+    |--------------------------------------------------------------------------
+    |
+    | If Expose is to consider this as a SSL port.
+    | this allows SSL use if you are using a non-standard SSL port.
+    | If null, assume SSL if 443, set to true to force SSL
+    | use false to force no SSL
+    |
+    */
+    'ssl' => null,
+
+    /*
+    |--------------------------------------------------------------------------
     | Auth Token
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
This Pull Request allows a user to configure the option `ssl` to enforce use of SSL or no SSL within the tunnel
It was made in such a way that the default of `null` will retain the current logic that expose uses which is `port === 443`

It is useful if you want to host expose on something other than port 443 while still using SSL.
Something else that could be added is warning a user if they use `'ssl' => false, 'port' => 443` as most browsers will reject this

My git skills failed me on #89 so I recreated the commits.