### PR TITLE
feat: Config option to set default protocol to https

### DIFF
--- a/app/Commands/ShareCurrentWorkingDirectoryCommand.php
+++ b/app/Commands/ShareCurrentWorkingDirectoryCommand.php
@@ -46,6 +46,6 @@ class ShareCurrentWorkingDirectoryCommand extends ShareCommand
 
     protected function prepareSharedHost($host): string
     {
-        return $this->detectProtocol($host) . $host;
+        return $this->detectProtocol($host).$host;
     }
 }

--- a/app/Commands/ShareCurrentWorkingDirectoryCommand.php
+++ b/app/Commands/ShareCurrentWorkingDirectoryCommand.php
@@ -33,14 +33,19 @@ class ShareCurrentWorkingDirectoryCommand extends ShareCommand
         return config('expose.default_tld', 'test');
     }
 
-    protected function prepareSharedHost($host): string
+    protected function detectProtocol($host): string
     {
         $certificateFile = ($_SERVER['HOME'] ?? $_SERVER['USERPROFILE']).DIRECTORY_SEPARATOR.'.config'.DIRECTORY_SEPARATOR.'valet'.DIRECTORY_SEPARATOR.'Certificates'.DIRECTORY_SEPARATOR.$host.'.crt';
 
         if (file_exists($certificateFile)) {
-            return 'https://'.$host;
+            return 'https://';
         }
 
-        return $host;
+        return config('expose.default_https', false) ? 'https://' : 'http://';
+    }
+
+    protected function prepareSharedHost($host): string
+    {
+        return $this->detectProtocol($host) . $host;
     }
 }

--- a/config/expose.php
+++ b/config/expose.php
@@ -57,6 +57,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Default HTTPS
+    |--------------------------------------------------------------------------
+    |
+    | Whether to use HTTPS as a default when sharing your local sites. Expose
+    | will try to look up the protocol if you are using Laravel Valet
+    | automatically. Otherwise you can specify it here manually.
+    |
+    */
+    'default_https' => false,
+
+    /*
+    |--------------------------------------------------------------------------
     | Maximum Logged Requests
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
When running `expose` without any options it tries to detect some Valet configuration and defaults to `http://[FOLDER].[DEFAULT_TLD]`. On some systems HTTPS may be the standard for sites, so I added an option to define whether HTTPS should be used as an default.