### PR TITLE
Associate shared sites with auth tokens

### DIFF
--- a/app/Contracts/ConnectionManager.php
+++ b/app/Contracts/ConnectionManager.php
@@ -23,4 +23,6 @@ interface ConnectionManager
     public function findControlConnectionForClientId(string $clientId): ?ControlConnection;
 
     public function getConnections(): array;
+
+    public function getConnectionsForAuthToken(string $authToken): array;
 }

--- a/app/Server/Connections/ControlConnection.php
+++ b/app/Server/Connections/ControlConnection.php
@@ -12,17 +12,19 @@ class ControlConnection
     /** @var ConnectionInterface */
     public $socket;
     public $host;
+    public $authToken;
     public $subdomain;
     public $client_id;
     public $proxies = [];
     protected $shared_at;
 
-    public function __construct(ConnectionInterface $socket, string $host, string $subdomain, string $clientId)
+    public function __construct(ConnectionInterface $socket, string $host, string $subdomain, string $clientId, string $authToken = '')
     {
         $this->socket = $socket;
         $this->host = $host;
         $this->subdomain = $subdomain;
         $this->client_id = $clientId;
+        $this->authToken = $authToken;
         $this->shared_at = now()->toDateTimeString();
     }
 
@@ -57,6 +59,7 @@ class ControlConnection
         return [
             'host' => $this->host,
             'client_id' => $this->client_id,
+            'auth_token' => $this->authToken,
             'subdomain' => $this->subdomain,
             'shared_at' => $this->shared_at,
         ];

--- a/app/Server/Factory.php
+++ b/app/Server/Factory.php
@@ -12,6 +12,7 @@ use App\Server\Http\Controllers\Admin\DeleteUsersController;
 use App\Server\Http\Controllers\Admin\DisconnectSiteController;
 use App\Server\Http\Controllers\Admin\GetSettingsController;
 use App\Server\Http\Controllers\Admin\GetSitesController;
+use App\Server\Http\Controllers\Admin\GetUserDetailsController;
 use App\Server\Http\Controllers\Admin\GetUsersController;
 use App\Server\Http\Controllers\Admin\ListSitesController;
 use App\Server\Http\Controllers\Admin\ListUsersController;
@@ -124,6 +125,7 @@ class Factory
         $this->router->post('/api/settings', StoreSettingsController::class, $adminCondition);
         $this->router->get('/api/users', GetUsersController::class, $adminCondition);
         $this->router->post('/api/users', StoreUsersController::class, $adminCondition);
+        $this->router->get('/api/users/{id}', GetUserDetailsController::class, $adminCondition);
         $this->router->delete('/api/users/{id}', DeleteUsersController::class, $adminCondition);
         $this->router->get('/api/sites', GetSitesController::class, $adminCondition);
         $this->router->delete('/api/sites/{id}', DisconnectSiteController::class, $adminCondition);

--- a/app/Server/Http/Controllers/Admin/GetUserDetailsController.php
+++ b/app/Server/Http/Controllers/Admin/GetUserDetailsController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Server\Http\Controllers\Admin;
+
+use App\Contracts\UserRepository;
+use Illuminate\Http\Request;
+use Ratchet\ConnectionInterface;
+
+class GetUserDetailsController extends AdminController
+{
+    protected $keepConnectionOpen = true;
+
+    /** @var UserRepository */
+    protected $userRepository;
+
+    public function __construct(UserRepository $userRepository)
+    {
+        $this->userRepository = $userRepository;
+    }
+
+    public function handle(Request $request, ConnectionInterface $httpConnection)
+    {
+        $this->userRepository
+            ->getUserById($request->get('id'))
+            ->then(function ($user) use ($httpConnection) {
+                $httpConnection->send(
+                    respond_json(['user' => $user])
+                );
+
+                $httpConnection->close();
+            });
+    }
+}

--- a/app/Server/Http/Controllers/ControlMessageController.php
+++ b/app/Server/Http/Controllers/ControlMessageController.php
@@ -127,7 +127,7 @@ class ControlMessageController implements MessageComponentInterface
     protected function verifyAuthToken(ConnectionInterface $connection): PromiseInterface
     {
         if (config('expose.admin.validate_auth_tokens') !== true) {
-            return new FulfilledPromise();
+            return \React\Promise\resolve(null);
         }
 
         $deferred = new Deferred();

--- a/tests/Feature/Server/AdminTest.php
+++ b/tests/Feature/Server/AdminTest.php
@@ -8,6 +8,7 @@ use Clue\React\Buzz\Browser;
 use Clue\React\Buzz\Message\ResponseException;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Support\Str;
+use Nyholm\Psr7\Request;
 use Psr\Http\Message\ResponseInterface;
 use Ratchet\Server\IoConnection;
 use Tests\Feature\TestCase;
@@ -149,6 +150,8 @@ class AdminTest extends TestCase
         $connectionManager = app(ConnectionManager::class);
 
         $connection = \Mockery::mock(IoConnection::class);
+        $connection->httpRequest = new Request('GET', '/?authToken=some-token');
+
         $connectionManager->storeConnection('some-host.text', 'fixed-subdomain', $connection);
 
         /** @var Response $response */

--- a/tests/Feature/Server/ApiTest.php
+++ b/tests/Feature/Server/ApiTest.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace Tests\Feature\Server;
+
+use App\Contracts\ConnectionManager;
+use App\Server\Factory;
+use Clue\React\Buzz\Browser;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Support\Str;
+use Nyholm\Psr7\Request;
+use Ratchet\Server\IoConnection;
+use Tests\Feature\TestCase;
+
+class ApiTest extends TestCase
+{
+    /** @var Browser */
+    protected $browser;
+
+    /** @var Factory */
+    protected $serverFactory;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->browser = new Browser($this->loop);
+        $this->browser = $this->browser->withOptions([
+            'followRedirects' => false,
+        ]);
+
+        $this->startServer();
+    }
+
+    public function tearDown(): void
+    {
+        $this->serverFactory->getSocket()->close();
+
+        parent::tearDown();
+    }
+
+    /** @test */
+    public function it_can_list_all_registered_users()
+    {
+        /** @var Response $response */
+        $this->await($this->browser->post('http://127.0.0.1:8080/api/users', [
+            'Host' => 'expose.localhost',
+            'Authorization' => base64_encode('username:secret'),
+            'Content-Type' => 'application/json',
+        ], json_encode([
+            'name' => 'Marcel',
+        ])));
+
+        /** @var Response $response */
+        $response = $this->await($this->browser->get('http://127.0.0.1:8080/api/users', [
+            'Host' => 'expose.localhost',
+            'Authorization' => base64_encode('username:secret'),
+            'Content-Type' => 'application/json',
+        ]));
+
+        $body = json_decode($response->getBody()->getContents());
+        $users = $body->paginated->users;
+
+        $this->assertCount(1, $users);
+        $this->assertSame('Marcel', $users[0]->name);
+        $this->assertSame([], $users[0]->sites);
+    }
+
+    /** @test */
+    public function it_can_get_user_details()
+    {
+        /** @var Response $response */
+        $this->await($this->browser->post('http://127.0.0.1:8080/api/users', [
+            'Host' => 'expose.localhost',
+            'Authorization' => base64_encode('username:secret'),
+            'Content-Type' => 'application/json',
+        ], json_encode([
+            'name' => 'Marcel',
+        ])));
+
+        /** @var Response $response */
+        $response = $this->await($this->browser->get('http://127.0.0.1:8080/api/users/1', [
+            'Host' => 'expose.localhost',
+            'Authorization' => base64_encode('username:secret'),
+            'Content-Type' => 'application/json',
+        ]));
+
+        $body = json_decode($response->getBody()->getContents());
+        $user = $body->user;
+
+        $this->assertSame('Marcel', $user->name);
+        $this->assertSame([], $user->sites);
+    }
+
+    /** @test */
+    public function it_can_list_all_currently_connected_sites_from_all_users()
+    {
+        /** @var Response $response */
+        $response = $this->await($this->browser->post('http://127.0.0.1:8080/api/users', [
+            'Host' => 'expose.localhost',
+            'Authorization' => base64_encode('username:secret'),
+            'Content-Type' => 'application/json',
+        ], json_encode([
+            'name' => 'Marcel',
+        ])));
+
+        $createdUser = json_decode($response->getBody()->getContents())->user;
+
+        /** @var ConnectionManager $connectionManager */
+        $connectionManager = app(ConnectionManager::class);
+
+        $connection = \Mockery::mock(IoConnection::class);
+        $connection->httpRequest = new Request('GET', '/?authToken='.$createdUser->auth_token);
+        $connectionManager->storeConnection('some-host.test', 'fixed-subdomain', $connection);
+
+        $connection = \Mockery::mock(IoConnection::class);
+        $connection->httpRequest = new Request('GET', '/?authToken=some-other-token');
+        $connectionManager->storeConnection('some-different-host.test', 'different-subdomain', $connection);
+
+        /** @var Response $response */
+        $response = $this->await($this->browser->get('http://127.0.0.1:8080/api/users', [
+            'Host' => 'expose.localhost',
+            'Authorization' => base64_encode('username:secret'),
+            'Content-Type' => 'application/json',
+        ]));
+
+        $body = json_decode($response->getBody()->getContents());
+        $users = $body->paginated->users;
+
+        $this->assertCount(1, $users[0]->sites);
+        $this->assertSame('some-host.test', $users[0]->sites[0]->host);
+        $this->assertSame('fixed-subdomain', $users[0]->sites[0]->subdomain);
+    }
+
+    /** @test */
+    public function it_can_list_all_currently_connected_sites()
+    {
+        /** @var ConnectionManager $connectionManager */
+        $connectionManager = app(ConnectionManager::class);
+
+        $connection = \Mockery::mock(IoConnection::class);
+        $connection->httpRequest = new Request('GET', '/?authToken=some-token');
+
+        $connectionManager->storeConnection('some-host.test', 'fixed-subdomain', $connection);
+
+        /** @var Response $response */
+        $response = $this->await($this->browser->get('http://127.0.0.1:8080/api/sites', [
+            'Host' => 'expose.localhost',
+            'Authorization' => base64_encode('username:secret'),
+            'Content-Type' => 'application/json',
+        ]));
+
+        $body = json_decode($response->getBody()->getContents());
+        $sites = $body->sites;
+
+        $this->assertCount(1, $sites);
+        $this->assertSame('some-host.test', $sites[0]->host);
+        $this->assertSame('some-token', $sites[0]->auth_token);
+        $this->assertSame('fixed-subdomain', $sites[0]->subdomain);
+    }
+
+    /** @test */
+    public function it_can_list_all_currently_connected_sites_without_auth_tokens()
+    {
+        /** @var ConnectionManager $connectionManager */
+        $connectionManager = app(ConnectionManager::class);
+
+        $connection = \Mockery::mock(IoConnection::class);
+        $connection->httpRequest = new Request('GET', '/');
+
+        $connectionManager->storeConnection('some-host.test', 'fixed-subdomain', $connection);
+
+        /** @var Response $response */
+        $response = $this->await($this->browser->get('http://127.0.0.1:8080/api/sites', [
+            'Host' => 'expose.localhost',
+            'Authorization' => base64_encode('username:secret'),
+            'Content-Type' => 'application/json',
+        ]));
+
+        $body = json_decode($response->getBody()->getContents());
+        $sites = $body->sites;
+
+        $this->assertCount(1, $sites);
+        $this->assertSame('some-host.test', $sites[0]->host);
+        $this->assertSame('', $sites[0]->auth_token);
+        $this->assertSame('fixed-subdomain', $sites[0]->subdomain);
+    }
+
+    protected function startServer()
+    {
+        $this->app['config']['expose.admin.subdomain'] = 'expose';
+        $this->app['config']['expose.admin.database'] = ':memory:';
+
+        $this->app['config']['expose.admin.users'] = [
+            'username' => 'secret',
+        ];
+
+        $this->serverFactory = new Factory();
+
+        $this->serverFactory->setLoop($this->loop)
+            ->createServer();
+    }
+}


### PR DESCRIPTION
This PR allows the association between a shared site and the authentication token / user.
It also adds a new API endpoint `/api/users/{ID}` which shows you all shared sites for a given user.
The paginated user API also contains a new `site` attribute that holds all shared sites for the user.