### PR TITLE
Allow custom config file path

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -37,6 +37,14 @@ class AppServiceProvider extends ServiceProvider
     {
         $builtInConfig = config('expose');
 
+        $keyServerVariable = 'EXPOSE_CONFIG_FILE';
+        if (array_key_exists($keyServerVariable, $_SERVER) && is_string($_SERVER[$keyServerVariable]) && file_exists($_SERVER[$keyServerVariable])) {
+            $localConfig = require $_SERVER[$keyServerVariable];
+            config()->set('expose', array_merge($builtInConfig, $localConfig));
+
+            return;
+        }
+
         $localConfigFile = getcwd().DIRECTORY_SEPARATOR.'.expose.php';
 
         if (file_exists($localConfigFile)) {

--- a/docs/client/configuration.md
+++ b/docs/client/configuration.md
@@ -17,6 +17,12 @@ The configuration file will be written to your home directory inside a `.expose`
 
 `~/.expose/config.php`
 
+You can also provide a custom location of the config file by providing the full path as a server variable.
+
+```bash
+EXPOSE_CONFIG_FILE="~/my-custom-config.php" expose publish
+```
+
 And the default content of the configuration file is this:
 
 ```php

--- a/docs/client/configuration.md
+++ b/docs/client/configuration.md
@@ -20,7 +20,7 @@ The configuration file will be written to your home directory inside a `.expose`
 You can also provide a custom location of the config file by providing the full path as a server variable.
 
 ```bash
-EXPOSE_CONFIG_FILE="~/my-custom-config.php" expose publish
+EXPOSE_CONFIG_FILE="~/my-custom-config.php" expose share
 ```
 
 And the default content of the configuration file is this:


### PR DESCRIPTION
**What does this PR do?**
It adds the ability to provide a path for your config file.

**Why this PR?**
Here are some use cases:
[Server] When you want to use multiple domains to be served by one expose codebase but with different databases.
[Client] You want to use multiple host domains without changing your config file.

**How to use this functionality**
Add `EXPOSE_CONFIG_FILE="/absolute/path/to/config.php"` to your expose command with the absolute path to your config file.