### PR TITLE
Removed fixed IP address for DNS

### DIFF
--- a/app/Client/Http/HttpClient.php
+++ b/app/Client/Http/HttpClient.php
@@ -66,7 +66,6 @@ class HttpClient
     protected function createConnector(): Connector
     {
         return new Connector($this->loop, [
-            'dns' => '127.0.0.1',
             'tls' => [
                 'verify_peer' => false,
                 'verify_peer_name' => false,


### PR DESCRIPTION
As described in #146 the fixed IP address for DNS can cause problems if another DNS is configured in the system.