### PR TITLE
make expose directly executable in the docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,3 +21,4 @@ ENV password=password
 ENV exposeConfigPath=/src/config/expose.php
 
 CMD sed -i "s|username|${username}|g" ${exposeConfigPath} && sed -i "s|password|${password}|g" ${exposeConfigPath} && php expose serve ${domain} --port ${port} --validateAuthTokens
+ENTRYPOINT ["/src/expose"]


### PR DESCRIPTION
executing expose in the container

before:
```
docker run -it expose ./expose
```

after:
```
docker run -it expose expose
```

inspiration taken from [cangelis' docker](https://github.com/cangelis/expose-docker)