### PR TITLE
Add built-in fileserver

### DIFF
--- a/app/Client/Configuration.php
+++ b/app/Client/Configuration.php
@@ -36,4 +36,16 @@ class Configuration
     {
         return intval($this->port);
     }
+
+    public function getUrl(string $subdomain): string
+    {
+        $httpProtocol = $this->port() === 443 ? 'https' : 'http';
+        $host = $this->host();
+
+        if ($httpProtocol !== 'https') {
+            $host .= ":{$this->port()}";
+        }
+
+        return "{$subdomain}.{$host}";
+    }
 }

--- a/app/Client/Fileserver/ConnectionHandler.php
+++ b/app/Client/Fileserver/ConnectionHandler.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace App\Client\Fileserver;
+
+use App\Http\Controllers\Concerns\LoadsViews;
+use App\Http\QueryParameters;
+use GuzzleHttp\Psr7\ServerRequest;
+use Illuminate\Http\Request;
+use Psr\Http\Message\ServerRequestInterface;
+use Ratchet\ConnectionInterface;
+use React\EventLoop\LoopInterface;
+use React\Http\Response;
+use React\Stream\ReadableResourceStream;
+use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\Glob;
+use Symfony\Component\Finder\Iterator\FilenameFilterIterator;
+use Symfony\Component\Finder\SplFileInfo;
+
+class ConnectionHandler
+{
+    use LoadsViews;
+
+    /** @var string */
+    protected $rootFolder;
+
+    /** @var string */
+    protected $name;
+
+    /** @var LoopInterface */
+    protected $loop;
+
+    public function __construct(string $rootFolder, string $name, LoopInterface  $loop)
+    {
+        $this->rootFolder = $rootFolder;
+        $this->name = $name;
+        $this->loop = $loop;
+    }
+
+    public function handle(ServerRequestInterface $request)
+    {
+        $request = $this->createLaravelRequest($request);
+        $targetPath = realpath($this->rootFolder . DIRECTORY_SEPARATOR . $request->path());
+
+        if (! $this->isValidTarget($targetPath)) {
+            return new Response(404);
+        }
+
+        if (is_dir($targetPath)) {
+            // Directory listing
+            $directoryContent = Finder::create()
+                ->depth(0)
+                ->sort(function ($a, $b) {
+                    return strcmp(strtolower($a->getRealpath()), strtolower($b->getRealpath()));
+                })
+                ->in($targetPath);
+
+            if ($this->name !== '') {
+                $directoryContent->name($this->name);
+            }
+
+            $parentPath = explode('/', $request->path());
+            array_pop($parentPath);
+            $parentPath = implode('/', $parentPath);
+
+            return new Response(
+                200,
+                ['Content-Type' => 'text/html'],
+                $this->getView(null, 'client.fileserver', [
+                    'currentPath' => $request->path(),
+                    'parentPath' => $parentPath,
+                    'directory' => $targetPath,
+                    'directoryContent' => $directoryContent
+                ])
+            );
+        }
+
+        if (is_file($targetPath)) {
+            return new Response(
+                200,
+                ['Content-Type' => mime_content_type($targetPath)],
+                new ReadableResourceStream(fopen($targetPath, 'r'), $this->loop)
+            );
+        }
+    }
+
+    protected function isValidTarget(string $targetPath): bool
+    {
+        if (! file_exists($targetPath)) {
+            return false;
+        }
+
+        if ($this->name !== '') {
+            $filter = new class(basename($targetPath), [$this->name]) extends FilenameFilterIterator {
+                protected $filename;
+
+                public function __construct(string $filename, array $matchPatterns)
+                {
+                    $this->filename = $filename;
+
+                    foreach ($matchPatterns as $pattern) {
+                        $this->matchRegexps[] = $this->toRegex($pattern);
+                    }
+                }
+
+                public function accept()
+                {
+                    return $this->isAccepted($this->filename);
+                }
+            };
+            return $filter->accept();
+        }
+
+        return true;
+    }
+
+    protected function createLaravelRequest(ServerRequestInterface $request): Request
+    {
+        try {
+            parse_str($request->getBody(), $bodyParameters);
+        } catch (\Throwable $e) {
+            $bodyParameters = [];
+        }
+
+        $serverRequest = (new ServerRequest(
+            $request->getMethod(),
+            $request->getUri(),
+            $request->getHeaders(),
+            $request->getBody(),
+            $request->getProtocolVersion(),
+        ))
+            ->withQueryParams(QueryParameters::create($request)->all())
+            ->withParsedBody($bodyParameters);
+
+        return Request::createFromBase((new HttpFoundationFactory)->createRequest($serverRequest));
+    }
+}

--- a/app/Client/Fileserver/ConnectionHandler.php
+++ b/app/Client/Fileserver/ConnectionHandler.php
@@ -7,15 +7,12 @@ use App\Http\QueryParameters;
 use GuzzleHttp\Psr7\ServerRequest;
 use Illuminate\Http\Request;
 use Psr\Http\Message\ServerRequestInterface;
-use Ratchet\ConnectionInterface;
 use React\EventLoop\LoopInterface;
 use React\Http\Response;
 use React\Stream\ReadableResourceStream;
 use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 use Symfony\Component\Finder\Finder;
-use Symfony\Component\Finder\Glob;
 use Symfony\Component\Finder\Iterator\FilenameFilterIterator;
-use Symfony\Component\Finder\SplFileInfo;
 
 class ConnectionHandler
 {
@@ -30,7 +27,7 @@ class ConnectionHandler
     /** @var LoopInterface */
     protected $loop;
 
-    public function __construct(string $rootFolder, string $name, LoopInterface  $loop)
+    public function __construct(string $rootFolder, string $name, LoopInterface $loop)
     {
         $this->rootFolder = $rootFolder;
         $this->name = $name;
@@ -40,7 +37,7 @@ class ConnectionHandler
     public function handle(ServerRequestInterface $request)
     {
         $request = $this->createLaravelRequest($request);
-        $targetPath = realpath($this->rootFolder . DIRECTORY_SEPARATOR . $request->path());
+        $targetPath = realpath($this->rootFolder.DIRECTORY_SEPARATOR.$request->path());
 
         if (! $this->isValidTarget($targetPath)) {
             return new Response(404);
@@ -70,7 +67,7 @@ class ConnectionHandler
                     'currentPath' => $request->path(),
                     'parentPath' => $parentPath,
                     'directory' => $targetPath,
-                    'directoryContent' => $directoryContent
+                    'directoryContent' => $directoryContent,
                 ])
             );
         }
@@ -108,6 +105,7 @@ class ConnectionHandler
                     return $this->isAccepted($this->filename);
                 }
             };
+
             return $filter->accept();
         }
 

--- a/app/Client/Fileserver/Fileserver.php
+++ b/app/Client/Fileserver/Fileserver.php
@@ -4,7 +4,6 @@ namespace App\Client\Fileserver;
 
 use Psr\Http\Message\ServerRequestInterface;
 use React\EventLoop\LoopInterface;
-use React\Http\Response;
 use React\Http\Server;
 use React\Socket\Server as SocketServer;
 

--- a/app/Client/Fileserver/Fileserver.php
+++ b/app/Client/Fileserver/Fileserver.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Client\Fileserver;
+
+use Psr\Http\Message\ServerRequestInterface;
+use React\EventLoop\LoopInterface;
+use React\Http\Response;
+use React\Http\Server;
+use React\Socket\Server as SocketServer;
+
+class Fileserver
+{
+    /** @var SocketServer */
+    protected $socket;
+
+    public function __construct($rootFolder, $name, $port, $address, LoopInterface $loop)
+    {
+        $server = new Server(function (ServerRequestInterface $request) use ($rootFolder, $name, $loop) {
+            return (new ConnectionHandler($rootFolder, $name, $loop))->handle($request);
+        });
+
+        $this->socket = new SocketServer("{$address}:{$port}", $loop);
+
+        $server->listen($this->socket);
+    }
+
+    public function getSocket(): SocketServer
+    {
+        return $this->socket;
+    }
+}

--- a/app/Client/Http/HttpClient.php
+++ b/app/Client/Http/HttpClient.php
@@ -92,7 +92,7 @@ class HttpClient
             ])
             ->send($request)
             ->then(function (ResponseInterface $response) use ($proxyConnection) {
-                if (!isset($response->buffer)) {
+                if (! isset($response->buffer)) {
                     $response = $this->rewriteResponseHeaders($response);
 
                     $response->buffer = str($response);
@@ -139,13 +139,13 @@ class HttpClient
 
     protected function rewriteResponseHeaders(ResponseInterface $response)
     {
-        if (!$response->hasHeader('Location')) {
+        if (! $response->hasHeader('Location')) {
             return $response;
         }
 
         $location = $response->getHeaderLine('Location');
 
-        if (!strstr($location, $this->connectionData->host)) {
+        if (! strstr($location, $this->connectionData->host)) {
             return $response;
         }
 

--- a/app/Client/ProxyManager.php
+++ b/app/Client/ProxyManager.php
@@ -32,7 +32,7 @@ class ProxyManager
         ], $this->loop)
             ->then(function (WebSocket $proxyConnection) use ($clientId, $connectionData) {
                 $proxyConnection->on('message', function ($message) use ($proxyConnection, $connectionData) {
-                    $this->performRequest($proxyConnection, $connectionData->request_id, (string) $message);
+                    $this->performRequest($proxyConnection, (string) $message, $connectionData);
                 });
 
                 $proxyConnection->send(json_encode([
@@ -76,8 +76,8 @@ class ProxyManager
             });
     }
 
-    protected function performRequest(WebSocket $proxyConnection, $requestId, string $requestData)
+    protected function performRequest(WebSocket $proxyConnection, string $requestData, $connectionData)
     {
-        app(HttpClient::class)->performRequest((string) $requestData, $proxyConnection, $requestId);
+        app(HttpClient::class)->performRequest((string) $requestData, $proxyConnection, $connectionData);
     }
 }

--- a/app/Commands/ShareFilesCommand.php
+++ b/app/Commands/ShareFilesCommand.php
@@ -25,7 +25,7 @@ class ShareFilesCommand extends Command
 
     public function handle()
     {
-        if ( !is_dir($this->argument('folder'))) {
+        if (! is_dir($this->argument('folder'))) {
             throw new \InvalidArgumentException('The folder '.$this->argument('folder').' does not exist.');
         }
 

--- a/app/Commands/ShareFilesCommand.php
+++ b/app/Commands/ShareFilesCommand.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Commands;
+
+use App\Client\Factory;
+use App\Logger\CliRequestLogger;
+use LaravelZero\Framework\Commands\Command;
+use React\EventLoop\LoopInterface;
+use Symfony\Component\Console\Output\ConsoleOutput;
+
+class ShareFilesCommand extends Command
+{
+    protected $signature = 'share-files {folder=.} {--name=} {--subdomain=} {--auth=}';
+
+    protected $description = 'Share a local folder with a remote expose server';
+
+    protected function configureConnectionLogger()
+    {
+        app()->bind(CliRequestLogger::class, function () {
+            return new CliRequestLogger(new ConsoleOutput());
+        });
+
+        return $this;
+    }
+
+    public function handle()
+    {
+        if ( !is_dir($this->argument('folder'))) {
+            throw new \InvalidArgumentException('The folder '.$this->argument('folder').' does not exist.');
+        }
+
+        $this->configureConnectionLogger();
+
+        (new Factory())
+            ->setLoop(app(LoopInterface::class))
+            ->setHost(config('expose.host', 'localhost'))
+            ->setPort(config('expose.port', 8080))
+            ->setAuth($this->option('auth'))
+            ->createClient()
+            ->shareFolder(
+                $this->argument('folder'),
+                $this->option('name') ?? '',
+                explode(',', $this->option('subdomain'))
+            )
+            ->createHttpServer()
+            ->run();
+    }
+}

--- a/app/Http/Controllers/Concerns/LoadsViews.php
+++ b/app/Http/Controllers/Concerns/LoadsViews.php
@@ -23,10 +23,10 @@ trait LoadsViews
         $data = array_merge($data, [
             'request' => $connection->laravelRequest ?? null,
         ]);
-try {
-        return stream_for($twig->render('template', $data));
-} catch (\Throwable $e) {
-    var_dump($e->getMessage());
-}
+        try {
+            return stream_for($twig->render('template', $data));
+        } catch (\Throwable $e) {
+            var_dump($e->getMessage());
+        }
     }
 }

--- a/app/Http/Controllers/Concerns/LoadsViews.php
+++ b/app/Http/Controllers/Concerns/LoadsViews.php
@@ -9,7 +9,7 @@ use Twig\Loader\ArrayLoader;
 
 trait LoadsViews
 {
-    protected function getView(ConnectionInterface $connection, string $view, array $data = [])
+    protected function getView(?ConnectionInterface $connection, string $view, array $data = [])
     {
         $templatePath = implode(DIRECTORY_SEPARATOR, explode('.', $view));
 
@@ -23,7 +23,10 @@ trait LoadsViews
         $data = array_merge($data, [
             'request' => $connection->laravelRequest ?? null,
         ]);
-
+try {
         return stream_for($twig->render('template', $data));
+} catch (\Throwable $e) {
+    var_dump($e->getMessage());
+}
     }
 }

--- a/app/Server/Connections/ControlConnection.php
+++ b/app/Server/Connections/ControlConnection.php
@@ -43,6 +43,8 @@ class ControlConnection
         $this->socket->send(json_encode([
             'event' => 'createProxy',
             'data' => [
+                'host' => $this->host,
+                'subdomain' => $this->subdomain,
                 'request_id' => $requestId,
                 'client_id' => $this->client_id,
             ],

--- a/app/Server/Http/Controllers/TunnelMessageController.php
+++ b/app/Server/Http/Controllers/TunnelMessageController.php
@@ -75,7 +75,7 @@ class TunnelMessageController extends Controller
 
         $httpConnection = $this->connectionManager->storeHttpConnection($httpConnection, $requestId);
 
-        transform($this->passRequestThroughModifiers($request, $httpConnection), function (Request $request) use ($controlConnection , $requestId) {
+        transform($this->passRequestThroughModifiers($request, $httpConnection), function (Request $request) use ($controlConnection, $requestId) {
             $controlConnection->once('proxy_ready_'.$requestId, function (ConnectionInterface $proxy) use ($request) {
                 // Convert the Laravel request into a PSR7 request
                 $psr17Factory = new Psr17Factory();

--- a/resources/views/client/fileserver.twig
+++ b/resources/views/client/fileserver.twig
@@ -1,0 +1,93 @@
+<html lang="en">
+<head>
+    <title>Expose Dashboard :: {{ subdomains|join(", ") }}</title>
+    <script src="https://cdn.jsdelivr.net/npm/vue@2.5.17/dist/vue.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tailwindcss/ui@latest/dist/tailwind-ui.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/clipboard@2/dist/clipboard.min.js"></script>
+    <link rel="stylesheet" href="//cdn.jsdelivr.net/gh/highlightjs/cdn-release@10.1.0/build/styles/github.min.css">
+    <script src="//cdn.jsdelivr.net/gh/highlightjs/cdn-release@10.1.0/build/highlight.min.js" async></script>
+</head>
+<body>
+<div id="app" class="">
+    <div class="relative bg-indigo-600" style="marign-left: -1px">
+        <div class="max-w-screen-xl mx-auto py-3 px-3 sm:px-6 lg:px-8">
+            <div class="pr-16 sm:text-center sm:px-16">
+                <p class="font-medium text-white flex justify-center">
+                    <span class="inline-block font-mono">{{ directory }}</span>
+                </p>
+            </div>
+        </div>
+    </div>
+    {% macro bytesToSize(bytes) %}
+            {% set kilobyte = 1024 %}
+            {% set megabyte = kilobyte * 1024 %}
+            {% set gigabyte = megabyte * 1024 %}
+            {% set terabyte = gigabyte * 1024 %}
+
+            {% if bytes < kilobyte %}
+                {{ bytes ~ ' B' }}
+            {% elseif bytes < megabyte %}
+                {{ (bytes / kilobyte)|number_format(2, '.') ~ ' KiB' }}
+            {% elseif bytes < gigabyte %}
+                {{ (bytes / megabyte)|number_format(2, '.') ~ ' MiB' }}
+            {% elseif bytes < terabyte %}
+                {{ (bytes / gigabyte)|number_format(2, '.') ~ ' GiB' }}
+            {% else %}
+                {{ (bytes / terabyte)|number_format(2, '.') ~ ' TiB' }}
+            {% endif %}
+    {% endmacro %}
+    <div class="flex flex-col px-6 py-4">
+        <div class="-my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+            <div class="py-2 align-middle inline-block min-w-full sm:px-6 lg:px-8">
+                <div class="shadow overflow-hidden border-b border-gray-200 sm:rounded-lg">
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead>
+                        <tr>
+                            <th class="px-6 py-3 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
+                                Name
+                            </th>
+                            <th class="px-6 py-3 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
+                                Date Modified
+                            </th>
+                            <th class="px-6 py-3 bg-gray-50 text-left text-xs leading-4 font-medium text-gray-500 uppercase tracking-wider">
+                                Size
+                            </th>
+                        </tr>
+                        </thead>
+                        <tbody class="bg-white">
+                        {% if currentPath != '/' %}
+                            <tr class="border-b">
+                                <td colspan="3" class="px-6 py-4 whitespace-no-wrap text-sm leading-5 font-mono text-gray-900">
+                                    <a href="/{{ parentPath }}" class="text-indigo-600 font-bold hover:text-indigo-900">Back</a>
+                                </td>
+                            </tr>
+                        {% endif %}
+                        {% for item in directoryContent %}
+                        <tr class="{% if loop.index % 2 == 0 %} bg-gray-50 {% endif %}">
+                            <td class="px-6 py-4 whitespace-no-wrap text-sm leading-5 font-mono text-gray-900">
+                                {% if currentPath != '/' %}
+                                    <a href="/{{ currentPath }}/{{ item.getFilename() }}" class="text-indigo-600 hover:text-indigo-900">{{ item.filename }}</a>
+                                {% else %}
+                                    <a href="/{{ item.getFilename() }}" class="text-indigo-600 hover:text-indigo-900">{{ item.filename }}</a>
+                                {% endif %}
+                            </td>
+                            <td class="px-6 py-4 whitespace-no-wrap text-sm leading-5 text-gray-500">
+                                {{ item.getMTime() | date("m/d/Y H:i:s") }}
+                            </td>
+                            <td class="px-6 py-4 whitespace-no-wrap text-sm leading-5 text-gray-500">
+                                {% if item.isDir() %}
+                                    -
+                                {% else %}
+                                    {{ _self.bytesToSize(item.getSize()) }}
+                                {% endif %}
+                            </td>
+                        </tr>
+                        {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/resources/views/client/fileserver.twig
+++ b/resources/views/client/fileserver.twig
@@ -1,6 +1,6 @@
 <html lang="en">
 <head>
-    <title>Expose Dashboard :: {{ subdomains|join(", ") }}</title>
+    <title>Expose Fileserver</title>
     <script src="https://cdn.jsdelivr.net/npm/vue@2.5.17/dist/vue.min.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tailwindcss/ui@latest/dist/tailwind-ui.min.css">
     <script src="https://cdn.jsdelivr.net/npm/clipboard@2/dist/clipboard.min.js"></script>

--- a/tests/Feature/Client/DashboardTest.php
+++ b/tests/Feature/Client/DashboardTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Client;
 
+use App\Client\Configuration;
 use App\Client\Factory;
 use App\Client\Http\HttpClient;
 use App\Logger\LoggedRequest;
@@ -129,6 +130,10 @@ class DashboardTest extends TestCase
 
     protected function startDashboard()
     {
+        app()->singleton(Configuration::class, function ($app) {
+            return new Configuration('localhost', '8080', false);
+        });
+
         $this->dashboardFactory = (new Factory())
             ->setLoop($this->loop)
             ->createHttpServer();

--- a/tests/Feature/Client/FileserverTest.php
+++ b/tests/Feature/Client/FileserverTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Tests\Feature\Client;
+
+use App\Client\Configuration;
+use App\Client\Factory;
+use App\Client\Http\HttpClient;
+use App\Logger\LoggedRequest;
+use App\Logger\RequestLogger;
+use Clue\React\Buzz\Browser;
+use Clue\React\Buzz\Message\ResponseException;
+use GuzzleHttp\Psr7\Request;
+use function GuzzleHttp\Psr7\str;
+use Mockery as m;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Tests\Feature\TestCase;
+
+class FileserverTest extends TestCase
+{
+    /** @var Browser */
+    protected $browser;
+
+    /** @var Factory */
+    protected $clientFactory;
+
+    /** @var string */
+    protected $fileserverUrl;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->browser = new Browser($this->loop);
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->clientFactory->getFileserver()->getSocket()->close();
+    }
+
+    /** @test */
+    public function accessing_the_fileserver_works()
+    {
+        $this->shareFolder(__DIR__);
+
+        /** @var ResponseInterface $response */
+        $response = $this->await($this->browser->get('http://'.$this->fileserverUrl));
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    /** @test */
+    public function accessing_invalid_files_returns_404()
+    {
+        $this->shareFolder(__DIR__);
+
+        $this->expectException(ResponseException::class);
+        $this->expectExceptionMessage(404);
+
+        /** @var ResponseInterface $response */
+        $response = $this->await($this->browser->get('http://'.$this->fileserverUrl.'/invalid-file'));
+
+        $this->assertSame(404, $response->getStatusCode());
+    }
+
+    /** @test */
+    public function it_can_return_filtered_responses()
+    {
+        $this->shareFolder(__DIR__.'/../../fixtures', '*.md');
+
+        $this->expectException(ResponseException::class);
+        $this->expectExceptionMessage(404);
+
+        /** @var ResponseInterface $response */
+        $response = $this->await($this->browser->get('http://'.$this->fileserverUrl.'/test.txt'));
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('test-file'.PHP_EOL, $response->getBody()->getContents());
+    }
+
+    /** @test */
+    public function it_can_return_file_responses()
+    {
+        $this->shareFolder(__DIR__.'/../../fixtures');
+
+        /** @var ResponseInterface $response */
+        $response = $this->await($this->browser->get('http://'.$this->fileserverUrl.'/test.txt'));
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('test-file'.PHP_EOL, $response->getBody()->getContents());
+    }
+
+    /** @test */
+    public function it_can_return_file_responses_for_valid_filtered_files()
+    {
+        $this->shareFolder(__DIR__.'/../../fixtures', '*.txt');
+
+        /** @var ResponseInterface $response */
+        $response = $this->await($this->browser->get('http://'.$this->fileserverUrl.'/test.txt'));
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('test-file'.PHP_EOL, $response->getBody()->getContents());
+    }
+
+    protected function shareFolder(string $folder, string $name = '')
+    {
+        app()->singleton(Configuration::class, function ($app) {
+            return new Configuration('localhost', '8080', false);
+        });
+
+        $factory = (new Factory())->setLoop($this->loop);
+        $this->fileserverUrl = $factory->createFileServer($folder, $name);
+        $this->clientFactory = $factory;
+    }
+}

--- a/tests/Feature/Client/FileserverTest.php
+++ b/tests/Feature/Client/FileserverTest.php
@@ -4,15 +4,8 @@ namespace Tests\Feature\Client;
 
 use App\Client\Configuration;
 use App\Client\Factory;
-use App\Client\Http\HttpClient;
-use App\Logger\LoggedRequest;
-use App\Logger\RequestLogger;
 use Clue\React\Buzz\Browser;
 use Clue\React\Buzz\Message\ResponseException;
-use GuzzleHttp\Psr7\Request;
-use function GuzzleHttp\Psr7\str;
-use Mockery as m;
-use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Tests\Feature\TestCase;
 

--- a/tests/fixtures/test.md
+++ b/tests/fixtures/test.md
@@ -1,0 +1,1 @@
+# Markdown

--- a/tests/fixtures/test.txt
+++ b/tests/fixtures/test.txt
@@ -1,0 +1,1 @@
+test-file


### PR DESCRIPTION
This PR adds a built-in fileserver to expose.

![image](https://user-images.githubusercontent.com/804684/97808935-218e0a00-1c6a-11eb-9cbc-3efaaf9d1be0.png)

Possible commands are:

```
# Share the current working directory
expose share-files

# Share a specific directory
expose share-files ~/Documents

# Share a specific directory, but filter the shared files using a regex/glob
expose share-files ~/Documents --name="*.jpg"
```

As this starts an internal HTTP server, it can be combined with all existing expose options, like specifying the subdomain, or adding basic authentication.