### PR TITLE
Rework http/s protocol

### DIFF
--- a/app/Client/Client.php
+++ b/app/Client/Client.php
@@ -60,11 +60,11 @@ class Client
             return $sharedUrl;
         }
 
-        $url = Arr::get($parsedUrl, 'host', Arr::get($parsedUrl, 'path'));
-        $scheme = Arr::get($parsedUrl, 'scheme');
+        $host = Arr::get($parsedUrl, 'host', Arr::get($parsedUrl, 'path', 'localhost'));
+        $scheme = Arr::get($parsedUrl, 'scheme', 'http');
         $port = Arr::get($parsedUrl, 'port', $scheme === 'https' ? 443 : 80);
 
-        return sprintf('%s:%s:%s', $scheme, $url, $port);
+        return sprintf('%s://%s:%s', $scheme, $host, $port);
     }
 
     public function connectToServer(string $sharedUrl, $subdomain, $authToken = ''): PromiseInterface

--- a/app/Client/Client.php
+++ b/app/Client/Client.php
@@ -45,7 +45,7 @@ class Client
         $sharedUrl = $this->prepareSharedUrl($sharedUrl);
 
         foreach ($subdomains as $subdomain) {
-            $this->connectToServerAndShareHttp($sharedUrl, $subdomain, $this->configuration->auth());
+            $this->connectToServer($sharedUrl, $subdomain, $this->configuration->auth());
         }
     }
 
@@ -67,7 +67,7 @@ class Client
         return sprintf('%s:%s:%s', $scheme, $url, $port);
     }
 
-    public function connectToServerAndShareHttp(string $sharedUrl, $subdomain, $authToken = ''): PromiseInterface
+    public function connectToServer(string $sharedUrl, $subdomain, $authToken = ''): PromiseInterface
     {
         $deferred = new Deferred();
         $promise = $deferred->promise();
@@ -88,7 +88,7 @@ class Client
                     $this->logger->error('Connection to server closed.');
 
                     $this->retryConnectionOrExit(function () use ($sharedUrl, $subdomain, $authToken) {
-                        $this->connectToServerAndShareHttp($sharedUrl, $subdomain, $authToken);
+                        $this->connectToServer($sharedUrl, $subdomain, $authToken);
                     });
                 });
 
@@ -121,7 +121,7 @@ class Client
             }, function (\Exception $e) use ($deferred, $sharedUrl, $subdomain, $authToken) {
                 if ($this->connectionRetries > 0) {
                     $this->retryConnectionOrExit(function () use ($sharedUrl, $subdomain, $authToken) {
-                        $this->connectToServerAndShareHttp($sharedUrl, $subdomain, $authToken);
+                        $this->connectToServer($sharedUrl, $subdomain, $authToken);
                     });
 
                     return;

--- a/app/Client/Http/HttpClient.php
+++ b/app/Client/Http/HttpClient.php
@@ -6,17 +6,17 @@ use App\Client\Configuration;
 use App\Client\Http\Modifiers\CheckBasicAuthentication;
 use App\Logger\RequestLogger;
 use Clue\React\Buzz\Browser;
-use Psr\Http\Message\UriInterface;
-use React\Stream\ReadableStreamInterface;
 use function GuzzleHttp\Psr7\parse_request;
 use function GuzzleHttp\Psr7\str;
 use Laminas\Http\Request;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\UriInterface;
 use Ratchet\Client\WebSocket;
 use Ratchet\RFC6455\Messaging\Frame;
 use React\EventLoop\LoopInterface;
 use React\Socket\Connector;
+use React\Stream\ReadableStreamInterface;
 
 class HttpClient
 {
@@ -107,7 +107,6 @@ class HttpClient
                     $response->buffer .= $chunk;
 
                     $this->sendChunkToServer($chunk, $proxyConnection);
-
                 });
 
                 $body->on('close', function () use ($proxyConnection, $response) {

--- a/app/Client/Http/HttpClient.php
+++ b/app/Client/Http/HttpClient.php
@@ -91,8 +91,6 @@ class HttpClient
             ->requestStreaming($request->getMethod(), $this->getExposeUri($request), $request->getHeaders(), $request->getBody())
             ->then(function (ResponseInterface $response) use ($proxyConnection) {
                 if (! isset($response->buffer)) {
-                    //$response = $this->rewriteResponseHeaders($response);
-
                     $response->buffer = str($response);
                 }
 
@@ -133,27 +131,6 @@ class HttpClient
     protected function parseRequest($data): Request
     {
         return Request::fromString($data);
-    }
-
-    protected function rewriteResponseHeaders(ResponseInterface $response)
-    {
-        if (! $response->hasHeader('Location')) {
-            return $response;
-        }
-
-        $location = $response->getHeaderLine('Location');
-
-        if (! strstr($location, $this->connectionData->host)) {
-            return $response;
-        }
-
-        $location = str_replace(
-            $this->connectionData->host,
-            $this->configuration->getUrl($this->connectionData->subdomain),
-            $location
-        );
-
-        return $response->withHeader('Location', $location);
     }
 
     private function getExposeUri(RequestInterface $request): UriInterface

--- a/app/Server/Connections/ConnectionManager.php
+++ b/app/Server/Connections/ConnectionManager.php
@@ -45,15 +45,13 @@ class ConnectionManager implements ConnectionManagerContract
 
     public function storeConnection(string $host, ?string $subdomain, ConnectionInterface $connection): ControlConnection
     {
-        $clientId = (string) uniqid();
-
-        $connection->client_id = $clientId;
+        $connection->client_id = sha1(uniqid('', true));
 
         $storedConnection = new ControlConnection(
             $connection,
             $host,
             $subdomain ?? $this->subdomainGenerator->generateSubdomain(),
-            $clientId,
+            $connection->client_id,
             $this->getAuthTokenFromConnection($connection)
         );
 

--- a/app/Server/Connections/ControlConnection.php
+++ b/app/Server/Connections/ControlConnection.php
@@ -3,7 +3,6 @@
 namespace App\Server\Connections;
 
 use Evenement\EventEmitterTrait;
-use Illuminate\Support\Str;
 use Ratchet\ConnectionInterface;
 
 class ControlConnection

--- a/app/Server/Connections/ControlConnection.php
+++ b/app/Server/Connections/ControlConnection.php
@@ -3,6 +3,7 @@
 namespace App\Server\Connections;
 
 use Evenement\EventEmitterTrait;
+use Illuminate\Support\Str;
 use Ratchet\ConnectionInterface;
 
 class ControlConnection

--- a/app/Server/Http/Controllers/TunnelMessageController.php
+++ b/app/Server/Http/Controllers/TunnelMessageController.php
@@ -113,9 +113,13 @@ class TunnelMessageController extends Controller
             $host .= ":{$this->configuration->port()}";
         }
 
-        $request->headers->set('Host', $controlConnection->host);
+        $exposeUrl = parse_url($controlConnection->host);
+
+        $request->headers->set('Host', "{$controlConnection->subdomain}.{$host}");
         $request->headers->set('X-Forwarded-Proto', $request->isSecure() ? 'https' : 'http');
-        $request->headers->set('X-Expose-Request-ID', uniqid());
+        $request->headers->set('X-Expose-Request-ID', sha1(uniqid('', true)));
+        $request->headers->set('X-Expose-Host', sprintf('%s:%s', $exposeUrl['host'], $exposeUrl['port']));
+        $request->headers->set('X-Expose-Proto', $exposeUrl['scheme']);
         $request->headers->set('Upgrade-Insecure-Requests', 1);
         $request->headers->set('X-Exposed-By', config('app.name').' '.config('app.version'));
         $request->headers->set('X-Original-Host', "{$controlConnection->subdomain}.{$host}");


### PR DESCRIPTION
In the current version, the host header is set incorrectly, which causes applications to incorrectly determine the correct host.

This PR fixes the error and sends the application the correct current header.

Also, two new `X-` headers are introduced to recognize what the exposed host + proto was, so that the proxy browser can determines the correct hostname, port and schema.

* `X-Expose-Host: <hostname>:<port>`
* `X-Expose-Proto: <schema>`

Furthermore a DSN support was introduced. So that also exposed HTTPS connections can be resolved.

Other changes in this pr:

* Changed the `X-Expose-Request-ID` to sha1 so it contains a hex string with a more entrophy uniqueid. 

--

I created this PR to share insights. This requires a major release and i think, there are few more places that should be reworked before a major release.