### PR TITLE
Fix docker entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,5 +20,6 @@ ENV username=username
 ENV password=password
 ENV exposeConfigPath=/src/config/expose.php
 
-CMD sed -i "s|username|${username}|g" ${exposeConfigPath} && sed -i "s|password|${password}|g" ${exposeConfigPath} && php expose serve ${domain} --port ${port} --validateAuthTokens
-ENTRYPOINT ["/src/expose"]
+COPY docker-entrypoint.sh /usr/bin/
+RUN chmod 755 /usr/bin/docker-entrypoint.sh
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+sed -i "s|username|${username}|g" ${exposeConfigPath} && sed -i "s|password|${password}|g" ${exposeConfigPath}
+
+if [[ $# -eq 0 ]]; then
+    exec /src/expose serve ${domain} --port ${port} --validateAuthTokens
+else
+    exec /src/expose "$@"
+fi


### PR DESCRIPTION
Hey,

You've created an amazing tool and I'm going to run on my own server (with Docker).
I see that a change on entrypoint in #149 causes a bug with CMD in Docker see in #165.

I purpose to create a custom endpoint to keep behavior for run default cmd and also a custom command if you want in your docker run.

I'm waiting your advise especially for entrypoint sh file that I've put on root but maybe you want to create a special folder for "Docker stuff".