### PR TITLE
Update Cuzzle to 3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "laminas/laminas-http": "^2.13",
         "laravel-zero/framework": "^8.2",
         "mockery/mockery": "^1.4.2",
-        "octoper/cuzzle": "^3.0",
+        "octoper/cuzzle": "^3.1",
         "nikic/php-parser": "^v4.10",
         "nyholm/psr7": "^1.3",
         "phpunit/phpunit": "^9.4.3",


### PR DESCRIPTION
This PR bumps an update to Cuzzle, which has a patch to fix escapeshellargs, allowing requests larger than 8k bytes to be processed.