### PR TITLE
Fix documentation link in home and 404 page

### DIFF
--- a/resources/views/server/errors/404.twig
+++ b/resources/views/server/errors/404.twig
@@ -34,7 +34,7 @@
             The tunnel "{{ subdomain }}" was not found on this Expose server.
         </p>
         <p class="pt-2 text-base">
-            Do you want to host your own Expose server? Check out the <a href="https://sharedwithexpose.com" class="underline">official documentation</a>.
+            Do you want to host your own Expose server? Check out the <a href="https://beyondco.de/docs/expose" class="underline">official documentation</a>.
         </p>
     </div>
 </div>

--- a/resources/views/server/homepage.twig
+++ b/resources/views/server/homepage.twig
@@ -31,7 +31,7 @@
     <div class="text-dark-blue-800 text-xl pt-16">
         <h1 class="text-2xl font-bold">Welcome to Expose</h1>
         <p class="pt-2 text-base">
-            Do you want to host your own Expose server? Check out the <a href="https://sharedwithexpose.com" class="underline">official documentation</a>.
+            Do you want to host your own Expose server? Check out the <a href="https://beyondco.de/docs/expose" class="underline">official documentation</a>.
         </p>
     </div>
 </div>


### PR DESCRIPTION
Looking for docs of `expose` I found out that the link in home (and 404 page) redirects to the same website instead of the official beyondco.de documentation.
Is it intended?

If not, here a PR to fix it, otherwise sorry :)

This PR replaces:
```
Do you want to host your own Expose server? Check out the <a href="https://sharedwithexpose.com" class="underline">official documentation</a>.
```

With:
```
Do you want to host your own Expose server? Check out the <a href="https://beyondco.de/docs/expose" class="underline">official documentation</a>.
```

In the homepage and 404 error page.