### PR TITLE
Welcome page can not be visited, when running Expose under a subdomain

### DIFF
--- a/app/Server/Http/Controllers/TunnelMessageController.php
+++ b/app/Server/Http/Controllers/TunnelMessageController.php
@@ -70,9 +70,7 @@ class TunnelMessageController extends Controller
 
     protected function detectSubdomain(Request $request): ?string
     {
-        $serverHost = $this->detectServerHost($request);
-
-        $subdomain = Str::before($request->header('Host'), '.'.$serverHost);
+        $subdomain = Str::before($request->header('Host'), '.'.$this->configuration->hostname());
 
         return $subdomain === $request->header('Host') ? null : $subdomain;
     }


### PR DESCRIPTION
Hi,

I am testing the v2 beta and noticed that the welcome page does not work any more, if you host Expose server under a subdomain.

For my personal setup I host Expose under share.mydomain.com (I want to avoid buying another domain just for hosting Expose). The admin panel is therefore under expose.share.mydomain.com available.

The method `detectSubdomain` does no longer respect the hostname under which the server is running. After I used the serverHost from configuration, it started to work again (This logic is the same as in the v1 master).

Ignore this PR if this is not meant to work, otherwise I hope this helps.

