### PR TITLE
s/form/div

### DIFF
--- a/resources/views/server/users/index.twig
+++ b/resources/views/server/users/index.twig
@@ -1,7 +1,7 @@
 {% extends "app" %}
 {% block title %}Users{% endblock %}
 {% block content %}
-<form class="flex flex-col py-8">
+<div class="flex flex-col py-8">
     <form>
         <div>
             <div>


### PR DESCRIPTION
On code review, this tag is closed by `</div>` and therefore should be an opening `<div>` and not ` <form>` as the form is actually opened on the next line! 