### PR TITLE
Always return '$this' in 'registerStatisticsCollector'

### DIFF
--- a/app/Server/Factory.php
+++ b/app/Server/Factory.php
@@ -310,7 +310,7 @@ class Factory
     protected function registerStatisticsCollector()
     {
         if (config('expose.admin.statistics.enable_statistics', true) === false) {
-            return;
+            return $this;
         }
 
         app()->singleton(StatisticsRepository::class, function () {


### PR DESCRIPTION
If you set config `expose.admin.statistics.enable_statistics` to false, the server will not start because "registerStatisticsCollector()" will not return it self ("Call to a member function bindConnectionManager() on null").