### PR TITLE
Docker container: access linux host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: "3.7"
 services:
   expose:
     image: beyondcodegmbh/expose-server:latest
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     ports:
       - 8080:${PORT}
     environment:


### PR DESCRIPTION
This PR adds host.docker.internal:host-gateway to extra_hosts section in docker-compose.yml

In docker for Mac and Windows hosts, we can connect to the host out of the box by using the special DNS name:host.docker.internal.

When docker is running under linux host, this is not the case. Under linux we need the magic string host-gateway to map to the gateway inside the container. This allows the hostname host.docker.internal to access the host from inside a container.

This fix is necessary for Linux users that use expose under docker and the webserver they want to expose is running as docker container too (ex. laravel sail).

The issue is explained in depth in this this article:
https://medium.com/@TimvanBaarsen/how-to-connect-to-the-docker-host-from-inside-a-docker-container-112b4c71bc66