### PR TITLE
FIX: Use "git" instead of "vcs" in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
     },
     "repositories": [
         {
-            "type": "vcs",
+            "type": "git",
             "url": "https://github.com/seankndy/reactphp-sqlite"
         }
     ],


### PR DESCRIPTION
Running `docker build .` was throwing this exception:

`Failed to clone the git@github.com:seankndy/reactphp-sqlite.git repository, try running in interactive mode so that you can enter your GitHub credentials` 

![image](https://user-images.githubusercontent.com/12491966/207224274-e136f509-26cb-49a2-81cc-2e54c382ade5.png)

Since `thatseankndy/reactphp-sqlite.git` is indeed a GitHub repo, I updated the composer.json repository to "git" instead of "vcs" fixed the issue. 
 