### PR TITLE
fix: bind configuration before binding a client in createClient

### DIFF
--- a/app/Client/Factory.php
+++ b/app/Client/Factory.php
@@ -108,9 +108,9 @@ class Factory
 
     public function createClient()
     {
-        $this->bindClient();
-
         $this->bindConfiguration();
+
+        $this->bindClient();
 
         $this->bindProxyManager();
 


### PR DESCRIPTION
Issue:

* in `app/Client/Factory.php`, `bindClient()` is called before `bindConfiguration()` in `createClient()`. This causes the created client to not have any changes to the configuration.  Namely, this causes `ShareCommand` to effectively ignore an input option for `--auth`, instead defaulting to whatever is in the `expose.php` config file.

* This change should fix the issue here: https://github.com/beyondcode/expose/issues/175 .  The asked-for `--token` option should already be satisfied by the `--auth` option, but due to this bug it was not behaving correctly.