### PR TITLE
Add timeout to port detection method

### DIFF
--- a/app/Factory.php
+++ b/app/Factory.php
@@ -173,7 +173,7 @@ class Factory
 
     protected function detectNextAvailablePort($startPort = 4040): int
     {
-        while (is_resource(@fsockopen('127.0.0.1', $startPort))) {
+        while (is_resource(@fsockopen('127.0.0.1', $startPort,  timeout: 1))) {
             $startPort++;
         }
 


### PR DESCRIPTION
Without adding timeout, it tries to connect to each host for default_socket_time (as defined in php.ini file) which adds up real quick and causes timeout error, possibly due to 20 seconds as default timeout for rachet.

fixes #464